### PR TITLE
C++ PassThrough with dual-mode endpoints (C++ or JS)

### DIFF
--- a/addon/binding.gyp
+++ b/addon/binding.gyp
@@ -2,7 +2,7 @@
   "targets": [
     {
       "target_name": "addon",
-      "sources": [ "addon.cc", "js-passthrough.cc" ]
+      "sources": [ "addon.cc", "js-passthrough.cc", "utils-inl.h" ]
     }
   ]
 }

--- a/addon/bob.h
+++ b/addon/bob.h
@@ -1,0 +1,28 @@
+#ifndef BOB_H_
+#define BOB_H_
+
+enum Status {
+  ERROR = -1,
+  END = 0,
+  CONTINUE = 1
+}
+
+class Sink;
+
+class Source {
+ public:
+  virtual ~Source() {}
+
+  virtual void BindSink(Sink* sink);
+  virtual void Pull(void** error, char* data, size_t size);
+};
+
+class Sink {
+ public:
+  virtual ~Sink() {}
+
+  virtual Sink* BindSource(Source* source);
+  virtual void Next(int status, void** error, char* data, size_t bytes);
+};
+
+#endif  // BOB_H_

--- a/addon/js-passthrough.cc
+++ b/addon/js-passthrough.cc
@@ -7,13 +7,163 @@
 napi_ref PassThrough::constructor;
 
 PassThrough::PassThrough()
-    : source_(nullptr), sink_(nullptr), env_(nullptr), wrapper_(nullptr) {}
+    : js_source_(nullptr),
+      js_sink_(nullptr),
+      env_(nullptr),
+      wrapper_(nullptr),
+      source_(nullptr),
+      sink_(nullptr) {}
 
-PassThrough::~PassThrough() { napi_delete_reference(env_, wrapper_); }
-
-void PassThrough::Destructor(napi_env env, void* nativeObject, void* /*finalize_hint*/) {
-  reinterpret_cast<PassThrough*>(nativeObject)->~PassThrough();
+PassThrough::~PassThrough() {
+  napi_delete_reference(env_, wrapper_);
+  if (js_source_ != nullptr) napi_delete_reference(env_, js_source_);
+  if (js_sink_ != nullptr) napi_delete_reference(env_, js_sink_);
 }
+
+// Called by N-API.
+void PassThrough::Destructor(napi_env env, void* nativeObject, void* /*finalize_hint*/) {
+  printf("### cleaned up\n");
+  delete static_cast<PassThrough*>(nativeObject);
+}
+
+// TODO: C++ only binding
+//
+// Sink* PassThrough::BindSource(Source* source) {
+//   if (js_source_ != nullptr) {
+//     printf("Should not bind from C++ when there is js_source_\n");
+//     return this;
+//   }
+//
+//   source->BindSink(this);
+//   source_ = reinterpret_cast<PassThrough*>(source);
+//
+//   return this;
+// }
+//
+// void PassThrough::BindSink(Sink* sink) {
+//   if (js_sink_ != nullptr) {
+//     printf("Should not bind from C++ when there is js_sink_\n");
+//     return;
+//   }
+//
+//   sink_ = reinterpret_cast<PassThrough*>(sink);
+// }
+
+//
+// C++ API
+//
+
+void PassThrough::Next(int bob_status, void** error, char* data, size_t bytes) {
+  // If we have bound to the C++ API
+  if (sink_ != nullptr) {
+    sink_->Next(bob_status, error, data, bytes);
+
+  // If we have bound to the JS API
+  } else if (js_sink_ != nullptr) {
+    napi_status status;
+
+    napi_value sink;
+    status = napi_get_reference_value(env_, js_sink_, &sink);
+    assert(status == napi_ok);
+
+    napi_value sink_next;
+    status = napi_get_named_property(env_, sink, "next", &sink_next);
+    assert(status == napi_ok);
+
+    napi_value buffer;
+    status = napi_create_buffer_copy(env_, bytes, data, nullptr, &buffer);
+    assert(status == napi_ok);
+
+    // If we had data from a JS buffer previously (probably) we need to free it.
+    if (buf_ref_ != nullptr) {
+      // XXX: Sometimes this can segfault with EXC_BAD_ACCESS
+      status = napi_delete_reference(env_, buf_ref_);
+      assert(status == napi_ok);
+      buf_ref_ = nullptr;
+    }
+
+    napi_value js_status;
+    status = napi_create_int32(env_, bob_status, &js_status);
+    assert(status == napi_ok);
+
+    napi_value js_bytes;
+    status = napi_create_int32(env_, bytes, &js_bytes);
+    assert(status == napi_ok);
+
+    size_t argc = 4;
+    const napi_value argv[] = {
+      js_status,
+      reinterpret_cast<napi_value>(*error),
+      buffer,
+      js_bytes
+    };
+
+    status = napi_make_callback(env_,
+                                nullptr,
+                                sink,
+                                sink_next,
+                                argc,
+                                argv,
+                                nullptr);
+    assert(status == napi_ok);
+
+  } else {
+    printf("PassThrough::Next called with invalid {js_}sink_ pointers\n");
+  }
+}
+
+void PassThrough::Pull(void** error, char* data, size_t size) {
+  // If we have bound to the C++ API
+  if (source_ != nullptr) {
+    source_->Pull(error, data, size);
+
+  // If we have bound to the JS API
+  } else if (js_source_ != nullptr) {
+    napi_status status;
+
+    napi_value source;
+    status = napi_get_reference_value(env_, js_source_, &source);
+    assert(status == napi_ok);
+
+    napi_value source_pull;
+    status = napi_get_named_property(env_, source, "pull", &source_pull);
+    assert(status == napi_ok);
+
+    napi_value buffer;
+    status = napi_create_buffer_copy(env_, size, data, nullptr, &buffer);
+    assert(status == napi_ok);
+
+    // If we had data from a JS buffer previously (probably) we need to free it.
+    if (buf_ref_ != nullptr) {
+      // XXX: Sometimes this can segfault with EXC_BAD_ACCESS
+      status = napi_delete_reference(env_, buf_ref_);
+      assert(status == napi_ok);
+      buf_ref_ = nullptr;
+    }
+
+    size_t argc = 2;
+    const napi_value argv[] = {
+      reinterpret_cast<napi_value>(*error),
+      buffer
+    };
+
+    status = napi_make_callback(env_,
+                                nullptr,
+                                source,
+                                source_pull,
+                                argc,
+                                argv,
+                                nullptr);
+    assert(status == napi_ok);
+
+  } else {
+    printf("PassThrough::Pull called with invalid {js_}sink_ pointers\n");
+  }
+}
+
+//
+// JavaScript API
+//
 
 #define DECLARE_NAPI_METHOD(name, func)                          \
   { name, 0, func, 0, 0, 0, napi_default, 0 }
@@ -53,17 +203,6 @@ napi_value PassThrough::New(napi_env env, napi_callback_info info) {
     napi_value jsthis;
     status = napi_get_cb_info(env, info, nullptr, nullptr, &jsthis, nullptr);
     assert(status == napi_ok);
-    //
-    // double value = 0;
-    //
-    // napi_valuetype valuetype;
-    // status = napi_typeof(env, args[0], &valuetype);
-    // assert(status == napi_ok);
-    //
-    // if (valuetype != napi_undefined) {
-    //   status = napi_get_value_double(env, args[0], &value);
-    //   assert(status == napi_ok);
-    // }
 
     PassThrough* obj = new PassThrough();
 
@@ -110,64 +249,41 @@ napi_value PassThrough::BindSource(napi_env env, napi_callback_info info) {
 
   napi_value source = argv[0];
 
-  napi_value global;
-  status = napi_get_global(env, &global);
+  napi_value js_bindsink;
+  status = napi_get_named_property(env, source, "bindSink", &js_bindsink);
   assert(status == napi_ok);
-  // PRINT_NAPI_TYPE(global, "0");
-
-  napi_value console;
-  status = napi_get_named_property(env,
-                                   global,
-                                   "console",
-                                   &console);
-  assert(status == napi_ok);
-  // PRINT_NAPI_TYPE(console, "1");
-
-  napi_value log_;
-  status = napi_get_named_property(env,
-                                   console,
-                                   "log",
-                                   &log_);
-  assert(status == napi_ok);
-  // PRINT_NAPI_TYPE(log_, "2");
-
-  napi_value console_args[1] = { source };
-  status = napi_call_function(env,
-                              console,
-                              log_,
-                              1,
-                              console_args,
-                              nullptr);
-  assert(status == napi_ok);
-
-
-  napi_value source_bindsink;
-  status = napi_get_named_property(env,
-                                   source,
-                                   "bindSink",
-                                   &source_bindsink);
-  assert(status == napi_ok);
-  // PRINT_NAPI_TYPE(source_bindsink, "4");
 
   napi_value argv_[1] = { jsthis };
   status = napi_call_function(env,
                               source,
-                              source_bindsink,
+                              js_bindsink,
                               1,
                               argv_,
                               nullptr);
-  // PRINT_NAPI_ERROR_MESSAGE(status, "source.bindSink()");
   assert(status == napi_ok);
 
   PassThrough* obj;
   status = napi_unwrap(env, jsthis, reinterpret_cast<void**>(&obj));
   assert(status == napi_ok);
 
-  napi_ref source_ref;
-  status = napi_create_reference(env, source, 1, &source_ref);
+  // Bind to the C++ API if it is available.
+  PassThrough* source_obj;
+  status = napi_unwrap(env, source, reinterpret_cast<void**>(&source_obj));
+  if (source_obj != nullptr && status == napi_ok) {
+    printf("bound c++ source!\n");
+    obj->source_ = source_obj;
+  }
+
+  // Set a JS property to hold the reference from being GC'd but in JS so it is
+  // still visible to the GC, then keep the C++ reference weakly.
+  status = napi_set_named_property(env, jsthis, "source", source);
   assert(status == napi_ok);
 
-  obj->source_ = source_ref;
+  napi_ref js_source_ref;
+  status = napi_create_reference(env, source, 0, &js_source_ref);
+  assert(status == napi_ok);
+
+  obj->js_source_ = js_source_ref;
 
   return jsthis;
 }
@@ -185,11 +301,26 @@ napi_value PassThrough::BindSink(napi_env env, napi_callback_info info) {
   status = napi_unwrap(env, jsthis, reinterpret_cast<void**>(&obj));
   assert(status == napi_ok);
 
-  napi_ref sink_ref;
-  status = napi_create_reference(env, argv[0], 1, &sink_ref);
+  // Bind to the C++ API if it is available.
+  PassThrough* sink_obj;
+  status = napi_unwrap(env, argv[0], reinterpret_cast<void**>(&sink_obj));
+  if (sink_obj != nullptr && status == napi_ok) {
+    printf("bound c++ sink!\n");
+    obj->sink_ = sink_obj;
+  }
+
+  napi_value sink = argv[0];
+
+  // Set a JS property to hold the reference from being GC'd but in JS so it is
+  // still visible to the GC, then keep the C++ reference weakly.
+  status = napi_set_named_property(env, jsthis, "sink", sink);
   assert(status == napi_ok);
 
-  obj->sink_ = sink_ref;
+  napi_ref sink_ref;
+  status = napi_create_reference(env, sink, 0, &sink_ref);
+  assert(status == napi_ok);
+
+  obj->js_sink_ = sink_ref;
 
   return nullptr;
 }
@@ -207,25 +338,54 @@ napi_value PassThrough::Next(napi_env env, napi_callback_info info) {
   status = napi_unwrap(env, jsthis, reinterpret_cast<void**>(&obj));
   assert(status == napi_ok);
 
-  napi_value sink;
-  status = napi_get_reference_value(env, obj->sink_, &sink);
-  assert(status == napi_ok);
+  // If we have bound to the C++ API
+  if (obj->sink_ != nullptr) {
+    int bob_status;
+    status = napi_get_value_int32(env, argv[0], &bob_status);
+    assert(status == napi_ok);
 
-  napi_value sink_next;
-  status = napi_get_named_property(env,
-                                   sink,
-                                   "next",
-                                   &sink_next);
-  assert(status == napi_ok);
+    status = napi_create_reference(env, argv[2], 1, &obj->buf_ref_);
+    assert(status == napi_ok);
 
-  status = napi_call_function(env,
-                              sink,
-                              sink_next,
-                              4,
-                              argv,
-                              nullptr);
-  assert(status == napi_ok);
+    char* data = nullptr;
+    size_t buffsize;
+    status = napi_get_buffer_info(env,
+                                  argv[2],
+                                  reinterpret_cast<void**>(&data),
+                                  &buffsize);
+    assert(status == napi_ok);
 
+    int bytes;
+    status = napi_get_value_int32(env, argv[3], &bytes);
+    assert(status == napi_ok);
+
+    printf("C++ -> C++ next!\n");
+
+    obj->sink_->Next(bob_status, reinterpret_cast<void**>(&argv[1]), data, bytes);
+
+  // If we have bound to the JS API
+  } else if (obj->js_sink_ != nullptr) {
+    napi_value sink;
+
+    status = napi_get_reference_value(env, obj->js_sink_, &sink);
+    assert(status == napi_ok);
+
+    napi_value sink_next;
+    status = napi_get_named_property(env, sink, "next", &sink_next);
+    assert(status == napi_ok);
+
+    status = napi_make_callback(env,
+                                nullptr,
+                                sink,
+                                sink_next,
+                                4,
+                                argv,
+                                nullptr);
+    assert(status == napi_ok);
+
+  } else {
+    printf("PassThrough::Next (JS) called with invalid {js_}sink_ pointers\n");
+  }
   return nullptr;
 }
 
@@ -242,30 +402,45 @@ napi_value PassThrough::Pull(napi_env env, napi_callback_info info) {
   status = napi_unwrap(env, jsthis, reinterpret_cast<void**>(&obj));
   assert(status == napi_ok);
 
-  napi_value source;
-  status = napi_get_reference_value(env, obj->source_, &source);
-  assert(status == napi_ok);
+  // If we have bound to the C++ API
+  if (obj->source_ != nullptr) {
+    status = napi_create_reference(env, argv[1], 1, &obj->buf_ref_);
+    assert(status == napi_ok);
 
-  // PRINT_NAPI_TYPE(source, "5");
+    char* data = nullptr;
+    size_t size;
+    status = napi_get_buffer_info(env,
+                                  argv[1],
+                                  reinterpret_cast<void**>(&data),
+                                  &size);
+    assert(status == napi_ok);
 
-  napi_value source_pull;
-  status = napi_get_named_property(env,
-                                   source,
-                                   "pull",
-                                   &source_pull);
-  assert(status == napi_ok);
+    printf("C++ -> C++ pull!\n");
 
-  // PRINT_NAPI_TYPE(source_pull, "5");
+    obj->source_->Pull(reinterpret_cast<void**>(&argv[0]), data, size);
 
-  status = napi_call_function(env,
-                              source,
-                              source_pull,
-                              2,
-                              argv,
-                              nullptr);
-  // PRINT_NAPI_ERROR_MESSAGE(status, "10");
-  // PRINT_NAPI_STATUS(status, "20");
-  // assert(status == napi_ok);
+  // If we have bound to the JS API
+  } else if (obj->js_source_ != nullptr) {
+    napi_value source;
 
+    status = napi_get_reference_value(env, obj->js_source_, &source);
+    assert(status == napi_ok);
+
+    napi_value js_pull;
+    status = napi_get_named_property(env, source, "pull", &js_pull);
+    assert(status == napi_ok);
+
+    status = napi_make_callback(env,
+                                nullptr,
+                                source,
+                                js_pull,
+                                2,
+                                argv,
+                                nullptr);
+    assert(status == napi_ok);
+
+  } else {
+    printf("PassThrough::Pull (JS) called with invalid {js_}sink_ pointers\n");
+  }
   return nullptr;
 }

--- a/addon/js-passthrough.h
+++ b/addon/js-passthrough.h
@@ -6,11 +6,18 @@
 class PassThrough {
  public:
   PassThrough();
-  ~PassThrough();
+  virtual ~PassThrough();
 
   static napi_value CreateClass(napi_env env);
 
   static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
+
+  // TODO: C++ only binding
+  //
+  // virtual Sink* BindSource(Source* source);
+  // virtual void BindSink(Sink* sink);
+  virtual void Next(int status, void** error, char* data, size_t bytes);
+  virtual void Pull(void** error, char* data, size_t size);
 
  private:
   static napi_value New(napi_env env, napi_callback_info info);
@@ -20,10 +27,15 @@ class PassThrough {
   static napi_value Pull(napi_env env, napi_callback_info info);
 
   static napi_ref constructor;
-  napi_ref source_;
-  napi_ref sink_;
+  napi_ref js_source_;
+  napi_ref js_sink_;
   napi_env env_;
   napi_ref wrapper_;
+
+  napi_ref buf_ref_;
+
+  PassThrough* source_;
+  PassThrough* sink_;
 };
 
 #endif  // JS_PASSTHROUGH_H_

--- a/addon/utils-inl.h
+++ b/addon/utils-inl.h
@@ -1,45 +1,117 @@
 #include <node_api.h>
 
-#define PRINT_NAPI_TYPE(value, str)                                                 \
-  {                                                                                 \
-    napi_valuetype type;                                                            \
-    napi_status status = napi_typeof(env, value, &type);                            \
-    assert(status == napi_ok);                                                      \
-                                                                                    \
-    if (type == napi_undefined) printf("%s - undefined\n", str);                    \
-    if (type == napi_null) printf("%s - null\n", str);                              \
-    if (type == napi_boolean) printf("%s - boolean\n", str);                        \
-    if (type == napi_number) printf("%s - number\n", str);                          \
-    if (type == napi_string) printf("%s - string\n", str);                          \
-    if (type == napi_symbol) printf("%s - symbol\n", str);                          \
-    if (type == napi_object) printf("%s - Object\n", str);                          \
-    if (type == napi_function) printf("%s - Function\n", str);                      \
-    if (type == napi_external) printf("%s - External\n", str);                      \
+#define PRINT_NAPI_TYPE(value, str)                                            \
+  {                                                                            \
+    napi_valuetype type;                                                       \
+    napi_status status = napi_typeof(env, value, &type);                       \
+    assert(status == napi_ok);                                                 \
+                                                                               \
+    if (type == napi_undefined) printf("%s - undefined\n", str);               \
+    if (type == napi_null) printf("%s - null\n", str);                         \
+    if (type == napi_boolean) printf("%s - boolean\n", str);                   \
+    if (type == napi_number) printf("%s - number\n", str);                     \
+    if (type == napi_string) printf("%s - string\n", str);                     \
+    if (type == napi_symbol) printf("%s - symbol\n", str);                     \
+    if (type == napi_object) printf("%s - Object\n", str);                     \
+    if (type == napi_function) printf("%s - Function\n", str);                 \
+    if (type == napi_external) printf("%s - External\n", str);                 \
   }
 
-#define PRINT_NAPI_STATUS(status, str) \
-{ \
-  if (status == napi_ok) printf("%s - ok\n", str); \
-  if (status == napi_invalid_arg) printf("%s - invalid_arg\n", str);           \
-  if (status == napi_object_expected) printf("%s - object_expected\n", str);        \
-  if (status == napi_string_expected) printf("%s - string_expected\n", str);      \
-  if (status == napi_name_expected) printf("%s - name_expected\n", str);       \
-  if (status == napi_function_expected) printf("%s - function_expecte\n", str);          \
-  if (status == napi_number_expected) printf("%s - number_expected\n", str);          \
-  if (status == napi_boolean_expected) printf("%s - boolean_expected\n", str);      \
-  if (status == napi_array_expected) printf("%s - array_expected\n", str); \
-  if (status == napi_generic_failure) printf("%s - generic_failure\n", str); \
-  if (status == napi_pending_exception) printf("%s - pending_exception\n", str); \
-  if (status == napi_cancelled) printf("%s - cancelled\n", str); \
+#define PRINT_NAPI_STATUS(s /* status */, str)                                 \
+{                                                                              \
+  if (s == napi_ok) printf("%s - ok\n", str);                                  \
+  if (s == napi_invalid_arg) printf("%s - invalid_arg\n", str);                \
+  if (s == napi_object_expected) printf("%s - object_expected\n", str);        \
+  if (s == napi_string_expected) printf("%s - string_expected\n", str);        \
+  if (s == napi_name_expected) printf("%s - name_expected\n", str);            \
+  if (s == napi_function_expected) printf("%s - function_expecte\n", str);     \
+  if (s == napi_number_expected) printf("%s - number_expected\n", str);        \
+  if (s == napi_boolean_expected) printf("%s - boolean_expected\n", str);      \
+  if (s == napi_array_expected) printf("%s - array_expected\n", str);          \
+  if (s == napi_generic_failure) printf("%s - generic_failure\n", str);        \
+  if (s == napi_pending_exception) printf("%s - pending_exception\n", str);    \
+  if (s == napi_cancelled) printf("%s - cancelled\n", str);                    \
 }
-// if (status == napi_status_last) printf("%s - status_last\n", str); \ // ????
 
-#define PRINT_NAPI_ERROR_MESSAGE(status, str)                                            \
-  {                                                                                 \
-    if (status != napi_ok) {                                                        \
-      const napi_extended_error_info* result;                                       \
-                                                                                    \
-      napi_get_last_error_info(env, &result);                                       \
-      printf("%s - %s\n", str, result->error_message);                              \
-    }                                                                               \
+#define PRINT_NAPI_ERROR_MESSAGE(status, str)                                  \
+  {                                                                            \
+    if (status != napi_ok) {                                                   \
+      const napi_extended_error_info* result;                                  \
+                                                                               \
+      napi_get_last_error_info(env, &result);                                  \
+      printf("%s - %s\n", str, result->error_message);                         \
+    }                                                                          \
+  }
+
+#define MAYBE_PRINT_NAPI_JS_EXCEPTION(str)                                     \
+  {                                                                            \
+    bool is_exception_pending;                                                 \
+    napi_status status_                                                        \
+    status_ = napi_is_exception_pending(env_, &is_exception_pending);          \
+    assert(status_ == napi_ok);                                                \
+                                                                               \
+    if (is_exception_pending) {                                                \
+      napi_value last_exception;                                               \
+      status_ = napi_get_and_clear_last_exception(env_,                        \
+                                                 &last_exception);             \
+      assert(status_ == napi_ok);                                              \
+                                                                               \
+                                                                               \
+      napi_value stack;                                                        \
+      status_ = napi_get_named_property(env,                                   \
+                                        last_exception,                        \
+                                        "stack",                               \
+                                        &stack);                               \
+      assert(status_ == napi_ok);                                              \
+                                                                               \
+      size_t string_length;                                                    \
+      status_ = napi_get_value_string_latin1(env,                              \
+                                             stack,                            \
+                                             nullptr,                          \
+                                             1000,                             \
+                                             &string_length);                  \
+      assert(status_ == napi_ok);                                              \
+                                                                               \
+      char* buf = new char[string_length];                                     \
+                                                                               \
+      status_ = napi_get_value_string_latin1(env,                              \
+                                            stack,                             \
+                                            buf,                               \
+                                            string_length,                     \
+                                            nullptr);                          \
+      assert(status_ == napi_ok);                                              \
+                                                                               \
+      delete[] buf;                                                            \
+                                                                               \
+      printf("Exception at: %s was %s\n", str, buf);                           \
+    }                                                                          \
+  }
+
+#define CONSOLE_LOG_JS_OBJECT(value, count)                                    \
+  {                                                                            \
+    napi_value global;                                                         \
+    status = napi_get_global(env, &global);                                    \
+    assert(status == napi_ok);                                                 \
+                                                                               \
+    napi_value console;                                                        \
+    status = napi_get_named_property(env,                                      \
+                                     global,                                   \
+                                     "console",                                \
+                                     &console);                                \
+    assert(status == napi_ok);                                                 \
+                                                                               \
+    napi_value log_;                                                           \
+    status = napi_get_named_property(env,                                      \
+                                     console,                                  \
+                                     "log",                                    \
+                                     &log_);                                   \
+    assert(status == napi_ok);                                                 \
+                                                                               \
+    status = napi_call_function(env,                                           \
+                                console,                                       \
+                                log_,                                          \
+                                count,                                         \
+                                value, /* c-style array */                     \
+                                nullptr);                                      \
+    assert(status == napi_ok);                                                 \
   }

--- a/reference-buffered-transform.js
+++ b/reference-buffered-transform.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Buffer } = require('buffer')
+const status_type = require('../status-enum')
 
 class BufferedTransform {
   constructor (bufferSize, reallocateSize) {
@@ -28,7 +29,7 @@ class BufferedTransform {
     if (error !== null) {
       return this.sink.next(status, error)
     }
-    if (status === 'end') {
+    if (status === status_type.end) {
       if (this._bytes === 0) {
         return this.sink.next(status)
       }
@@ -49,7 +50,7 @@ class BufferedTransform {
     buffer.copy(this._buffer, this._bytes, 0, bytes)
     this._bytes += bytes
 
-    if (status === 'continue') {
+    if (status === status_type.continue) {
       return this.source.pull(null, buffer)
     }
   }
@@ -60,14 +61,14 @@ class BufferedTransform {
     }
 
     if (this._readPos >= this._bytes) {
-      this.sink.next('end')
+      this.sink.next(status_type.end)
     }
 
     this._buffer.copy(buffer, 0, this._readPos)
 
     this._readPos += buffer.length
 
-    this.sink.next('continue', null, buffer, buffer.length)
+    this.sink.next(status_type.continue, null, buffer, buffer.length)
   }
 }
 

--- a/reference-sink.js
+++ b/reference-sink.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Buffer } = require('buffer')
+const status_type = require('../status-enum')
 
 class Sink {
   constructor () {
@@ -24,7 +25,7 @@ class Sink {
 
   next (status, error, buffer, bytes) {
     // status MUST be a valid status indicator (string currently)
-    //  options are: 'error', 'continue', or 'end'
+    //  options are: status_type.error, status_type.continue, or status_type.end
     // error MUST be null or an error
     // buffer MUST be a Buffer
     // bytes MUST be the number of bytes read

--- a/reference-source.js
+++ b/reference-source.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const status_type = require('../status-enum')
+
 class Source {
   constructor () {
     this.sink = null
@@ -14,14 +16,14 @@ class Source {
     // error MUST be null or an error
     // buffer MUST be a Buffer
     if (error || sourceError) {
-      return this.sink.next('error', error)
+      return this.sink.next(status_type.error, error)
     }
 
     // read into buffer
     if (more) {
-      this.sink.next('continue', null, buffer, bytesWritten)
+      this.sink.next(status_type.continue, null, buffer, bytesWritten)
     } else {
-      this.sink.next('end', null, buffer, bytesWritten)
+      this.sink.next(status_type.end, null, buffer, bytesWritten)
     }
   }
 }

--- a/status-enum.js
+++ b/status-enum.js
@@ -1,0 +1,5 @@
+module.exports = {
+  error: -1,
+  end: 0,
+  continue: 1
+}

--- a/stdio/stdout-sink.js
+++ b/stdio/stdout-sink.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Buffer } = require('buffer')
+const status_type = require('../status-enum')
 
 class StdoutSink {
   constructor () {
@@ -28,7 +29,7 @@ class StdoutSink {
   }
 
   next (status, error, buffer, bytes) {
-    if (status === 'end') return
+    if (status === status_type.end) return
     if (error) bindCb(error)
 
     process.stdout.write(buffer.slice(0, bytes))

--- a/tests/file-to-file-test-c++-double.js
+++ b/tests/file-to-file-test-c++-double.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const FileSource = require('../fs/file-source')
+const FileSink = require('../fs/file-sink')
+const PassThrough = require('../addon/build/Release/addon')
+
+const fileSource = new FileSource(process.argv[2])
+const fileSink = new FileSink(process.argv[2] + '_')
+const passThrough1 = new PassThrough()
+const passThrough2 = new PassThrough()
+
+fileSink.bindSource(passThrough1.bindSource(passThrough2.bindSource(fileSource)), error => {
+  if (error)
+    console.error('ERROR!', error)
+  else {
+    console.log('done')
+  }
+})


### PR DESCRIPTION
Initial working implementation of a C++ based PassThrough which also acts as a "transform" between the C++ and JS API, being able to pass through to either API.

Currently comes with an potential C++ abstract interface, but that doesn't currently function due to how C++ interface classes work.

This follows how I developed the JS API (class / object based) but it is possible that we will land on something more 'functional' in a future iteration.

Also changes the JS status passing to use an enum / number statuses.

cc @addaleax, @jasnell, @mcollina, @trevnorris - if any of you want to take a peek before I squash and merge in a few days.